### PR TITLE
Fix compilation with disabled features

### DIFF
--- a/src/defs.rs
+++ b/src/defs.rs
@@ -18,7 +18,9 @@ macro_rules! defs {
         $(
             pub const $name: Def = Def {
                 code: $code,
+                #[cfg(feature = "proj4")]
                 proj4: $proj4,
+                #[cfg(feature = "wkt")]
                 wkt: $wkt,
             };
         )*


### PR DESCRIPTION
The macro adds proj and wkt fields even if the respective features are not enabled and thus the fields are not present